### PR TITLE
add element without a reverse proxy config

### DIFF
--- a/sczi/element/README.md
+++ b/sczi/element/README.md
@@ -1,0 +1,15 @@
+# element
+
+Base image: https://hub.docker.com/r/vectorim/element-web/
+
+An instance of the Riot/Element Matrix web client.
+
+runs on host port `7331`.
+
+## Configuration
+
+The local `./element-config.json` is mapped to `/app/config.json` -- any changes made should be reflected.
+
+## Running it
+
+Run `docker-compose up -d`.

--- a/sczi/element/docker-compose.yml
+++ b/sczi/element/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3'
+
+services:
+  element:
+    image: vectorim/element-web:latest
+    restart: unless-stopped
+    volumes:
+      - ./element-config.json:/app/config.json
+    ports: 
+      - "7331:80"
+
+networks:
+  default:
+    external:
+      name: vtluug-network

--- a/sczi/element/element-config.json
+++ b/sczi/element/element-config.json
@@ -1,0 +1,62 @@
+{
+    "default_server_name": "matrix.org",
+    "default_server_config": {
+        "m.homeserver": {
+            "base_url": "https://matrix-client.matrix.org"
+        },
+        "m.identity_server": {
+            "base_url": "https://vector.im"
+        }
+    },
+    "brand": "Element",
+    "integrations_ui_url": "https://scalar.vector.im/",
+    "integrations_rest_url": "https://scalar.vector.im/api",
+    "integrations_widgets_urls": [
+        "https://scalar.vector.im/_matrix/integrations/v1",
+        "https://scalar.vector.im/api",
+        "https://scalar-staging.vector.im/_matrix/integrations/v1",
+        "https://scalar-staging.vector.im/api",
+        "https://scalar-staging.riot.im/scalar/api"
+    ],
+    "bug_report_endpoint_url": "https://element.io/bugreports/submit",
+    "uisi_autorageshake_app": "element-auto-uisi",
+    "show_labs_settings": true,
+    "room_directory": {
+        "servers": ["matrix.org", "gitter.im", "libera.chat"]
+    },
+    "enable_presence_by_hs_url": {
+        "https://matrix.org": false,
+        "https://matrix-client.matrix.org": false
+    },
+    "terms_and_conditions_links": [
+        {
+            "url": "https://element.io/privacy",
+            "text": "Privacy Policy"
+        },
+        {
+            "url": "https://element.io/cookie-policy",
+            "text": "Cookie Policy"
+        }
+    ],
+    "sentry": {
+        "dsn": "https://029a0eb289f942508ae0fb17935bd8c5@sentry.matrix.org/6",
+        "environment": "develop"
+    },
+    "posthog": {
+        "project_api_key": "phc_Jzsm6DTm6V2705zeU5dcNvQDlonOR68XvX2sh1sEOHO",
+        "api_host": "https://posthog.element.io"
+    },
+    "privacy_policy_url": "https://element.io/cookie-policy",
+    "features": {
+        "feature_video_rooms": true,
+        "feature_new_room_decoration_ui": true,
+        "feature_element_call_video_rooms": true
+    },
+    "setting_defaults": {
+        "RustCrypto.staged_rollout_percent": 100
+    },
+    "element_call": {
+        "url": "https://call.element.dev"
+    },
+    "map_style_url": "https://api.maptiler.com/maps/streets/style.json?key=fU3vlMsMn4Jb6dnEIFsx"
+}


### PR DESCRIPTION
a bare element instance that *doesn't* get reverse-proxied up by nginx, mostly because I can't at the moment make a new subdomain for it. i'll get that fixed at the meeting.

synapse requires some manual (read: root) configuration, so that'll wait until the meeting too.