### PR TITLE
fix: explicitly name a few containers

### DIFF
--- a/sczi/class_util/docker-compose.yml
+++ b/sczi/class_util/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   web:
     restart: unless-stopped
     image: philipconte/class_util
+    container_name: classutil
     volumes:
       - /nfs/cistern/docker/data/class_util:/data
     env_file: .env

--- a/sczi/element/docker-compose.yml
+++ b/sczi/element/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3'
 services:
   element:
     image: vectorim/element-web:latest
+    container_name: element
     restart: unless-stopped
     volumes:
       - /nfs/cistern/docker/apps/sczi/element/element-config.json:/app/config.json

--- a/sczi/nginx/site-confs/bash.vtluug.org.enabled
+++ b/sczi/nginx/site-confs/bash.vtluug.org.enabled
@@ -19,6 +19,6 @@ server {
     location / {
         # Proxy to pyqdb container
         include /config/nginx/proxy.conf;
-        proxy_pass http://pyqdb_pyqdb_1:8080;
+        proxy_pass http://pyqdb:8080;
     }
 }

--- a/sczi/nginx/site-confs/distributions.pconte.me
+++ b/sczi/nginx/site-confs/distributions.pconte.me
@@ -19,6 +19,6 @@ server {
     location / {
         # Proxy to container
         include /config/nginx/proxy.conf;
-        proxy_pass http://classutil_web_1:8000;
+        proxy_pass http://classutil:8000;
     }
 }

--- a/sczi/nginx/site-confs/element.vtluug.org.enabled
+++ b/sczi/nginx/site-confs/element.vtluug.org.enabled
@@ -19,6 +19,6 @@ server {
     location / {
         # Proxy to container
         include /config/nginx/proxy.conf;
-        proxy_pass http://element_element_1:80;
+        proxy_pass http://element:80;
     }
 }

--- a/sczi/nginx/site-confs/irc.vtluug.org.enabled
+++ b/sczi/nginx/site-confs/irc.vtluug.org.enabled
@@ -19,6 +19,6 @@ server {
     location / {
         # Proxy to container
         include /config/nginx/proxy.conf;
-        proxy_pass http://thelounge_fourget_1:9000;
+        proxy_pass http://thelounge:9000;
     }
 }

--- a/sczi/pyqdb/docker-compose.yml
+++ b/sczi/pyqdb/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     restart: unless-stopped
     env_file: pyqdb.env
     image: vtluug/pyqdb
+    container_name: pyqdb
     volumes:
       - /nfs/cistern/docker/data/pyqdb/quotes.db:/app/quotes.db
 

--- a/sczi/thelounge/docker-compose.yml
+++ b/sczi/thelounge/docker-compose.yml
@@ -3,12 +3,13 @@ version: '3'
 services:
   fourget:
     image: thelounge/thelounge:latest
+    container_name: thelounge
     restart: always
 
     ports:
       - 113:9001
       #- 9009:9000
-      
+
     volumes:
       - /nfs/cistern/docker/data/thelounge/:/var/opt/thelounge
 


### PR DESCRIPTION
fixes #20

distributions.pconte.me just redirects to vtluug.org lol. still changed it because why not

it's actually very cool that you can refer to a container name like you can localhost. i need to read about this stuff!