### PR TITLE
nginx: prefer /~user over /users/~user

### DIFF
--- a/sczi/nginx/site-confs/vtluug.org.enabled
+++ b/sczi/nginx/site-confs/vtluug.org.enabled
@@ -57,6 +57,10 @@ server {
     }
 
     location ~ ^/users/~(.+?)(/.*)?$ {
+        return 301 $scheme://vtluug.org/~$1$2;
+    }
+
+    location ~ ^/~(.+?)(/.*)?$ {
         alias /users/$1/public_html$2;
         index index.html index.htm;
         autoindex on;
@@ -76,7 +80,7 @@ server {
         rewrite ^/wiki$ /w/index.php last;
         rewrite ^/wiki/(.*)$ /w/index.php/$1 last;
     }
-    
+
     # Redirect & cache images
     location /w/images {
         alias /wiki-images/vtluug;


### PR DESCRIPTION
http redirects `/users/~user` to `/~user` for backcompat 